### PR TITLE
Make stack input optional

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,7 @@ on:
         type: string
       stack:
         description: "The stack to deploy to"
-        required: true
+        required: false
         type: string
     secrets:
       DEPLOY_GITHUB_USER:


### PR DESCRIPTION
Ping @msimmons 

MFP-1578

In lieu of the new `[uat]` command that has no stacks, make the stack input optional